### PR TITLE
return fig, axs after saving figure, just like in gridshow

### DIFF
--- a/python/phloutput.py
+++ b/python/phloutput.py
@@ -1686,10 +1686,10 @@ class h5plane:
 
      cb = fig.colorbar(im,cax=cax,label=cb_lbl,orientation=orientation)
 
-     return fig,axs
-
      if(figname!=None):
       savefig(figname,dpi=figdpi)
+     
+     return fig,axs
 
      if(showfig):
       show()

--- a/python/phloutput.py
+++ b/python/phloutput.py
@@ -1688,8 +1688,6 @@ class h5plane:
 
      if(figname!=None):
       savefig(figname,dpi=figdpi)
-     
-     return fig,axs
 
      if(showfig):
       show()
@@ -1698,6 +1696,7 @@ class h5plane:
 
      rc('text', usetex=False)
 
+     return fig,axs
 #######################################################################################
 # h5grid class
 #######################################################################################
@@ -2669,8 +2668,6 @@ class h5grid:
      if(figname!=None):
       savefig(figname,dpi=figdpi)
 
-     return fig,axs
-
      if(showfig):
       show()
      elif(multiplot):
@@ -2679,6 +2676,8 @@ class h5grid:
       close()
 
      rc('text', usetex=False)
+
+     return fig,axs
 
     def radialshow(self,quant,ib_bins=None,slices=False,s1=-1,s2=-1,s3=-1, \
                     figdpi=500,figname=None, \


### PR DESCRIPTION
Otherwise the figure will not be saved

## Summary

Switched order of `return fig, axs` and the `savefig` command.

## Motivation

Planeshow did not save my plots before that.

## Related issue (optional)

No issue is required for feature pull requests.

- Optional link: #<issue-number>

## Verification

Describe what you built and ran to validate the change.

- Affected test case(s):
- Commands used:
- Key output or behavior observed:

## Checklist

- [ ] Documentation was updated where behavior, options, or workflows changed.
- [ ] Relevant local checks were run.
- [ ] CI checks are passing (required before merge).
- [ ] If a new feature is implemented, it was verified by local test simulations
