### PR TITLE
Pig opr eqm

### DIFF
--- a/docs/source/modules/generate_pig_table.md
+++ b/docs/source/modules/generate_pig_table.md
@@ -17,7 +17,8 @@ To generate a customized table for a partially-ionized-gas (PIG) EoS, you must f
 | `ddx2=8` | Number of briquettes in the temperature axis used for MPI parallelization |
 | `USE_QUAD_PRECISION` | To enable 128-bit precision (recommended), otherwise use `USE_DOUBLE_PRECISION` |
 | `USE_H2` | If enabled, adds h2 to the mixture |
- 
+| `USE_OPR_EQM` | If enabled, assume p-h2 to o-h2 at equilibrium ratio; if disabled, assume 3 to 1 ratio. Requires `USE_H2` |
+
 The provided Makefile will use `mpifort` to compile the source code, but you can explicitly set the fortran compiler at `FC = mpifort`.
 
 The mass fractional abundances of a finite list of elements must be provided in `generate_pig_table.F90` as

--- a/docs/source/modules/generate_pig_table.md
+++ b/docs/source/modules/generate_pig_table.md
@@ -17,7 +17,7 @@ To generate a customized table for a partially-ionized-gas (PIG) EoS, you must f
 | `ddx2=8` | Number of briquettes in the temperature axis used for MPI parallelization |
 | `USE_QUAD_PRECISION` | To enable 128-bit precision (recommended), otherwise use `USE_DOUBLE_PRECISION` |
 | `USE_H2` | If enabled, adds h2 to the mixture |
-| `USE_OPR_EQM` | If enabled, assume p-h2 to o-h2 at equilibrium ratio; if disabled, assume 3 to 1 ratio. Requires `USE_H2` |
+| `USE_OPR_EQM` | If enabled, assumes para-h2 to orth-h2 at equilibrium ratio; if disabled, assumes 3 to 1 ratio. |
 
 The provided Makefile will use `mpifort` to compile the source code, but you can explicitly set the fortran compiler at `FC = mpifort`.
 

--- a/miscellaneous/generate_pig_table/Makefile
+++ b/miscellaneous/generate_pig_table/Makefile
@@ -1,17 +1,18 @@
 SRC = ./source
 APPNAME = generate_pig_table
 
-OPTS = Nrho=400
-OPTS += NT=400
+OPTS = Nrho=100
+OPTS += NT=100
 OPTS += log10_T_min=1.0_rp
 OPTS += log10_T_max=8.0_rp
 OPTS += log10_rho_min=-20.0_rp
 OPTS += log10_rho_max=0.0_rp
 OPTS += thr_ne=1.0e-20_rp
 OPTS += eps_eta=1.0e-3_rp
-OPTS += ddx1=8
-OPTS += ddx2=8
+OPTS += ddx1=2
+OPTS += ddx2=2
 OPTS += USE_QUAD_PRECISION
+OPTS += USE_OPR_EQM
 OPTS += USE_H2
 
 #--------------------------------#

--- a/miscellaneous/generate_pig_table/Makefile
+++ b/miscellaneous/generate_pig_table/Makefile
@@ -1,16 +1,16 @@
 SRC = ./source
 APPNAME = generate_pig_table
 
-OPTS = Nrho=100
-OPTS += NT=100
+OPTS = Nrho=400
+OPTS += NT=400
 OPTS += log10_T_min=1.0_rp
 OPTS += log10_T_max=8.0_rp
 OPTS += log10_rho_min=-20.0_rp
 OPTS += log10_rho_max=0.0_rp
 OPTS += thr_ne=1.0e-20_rp
 OPTS += eps_eta=1.0e-3_rp
-OPTS += ddx1=2
-OPTS += ddx2=2
+OPTS += ddx1=8
+OPTS += ddx2=8
 OPTS += USE_QUAD_PRECISION
 OPTS += USE_OPR_EQM
 OPTS += USE_H2

--- a/miscellaneous/generate_pig_table/source/source.F90
+++ b/miscellaneous/generate_pig_table/source/source.F90
@@ -1158,7 +1158,7 @@ contains
    real(kind=rp) :: phij(nlev_max),Pj(nlev_max)
    real(kind=rp) :: nl(niso)
    integer :: nstages 
-   real(kind=rp) :: CI,Sl,T,ni,rho,tmp,a1,a2,a3,Zrot,Zh2ext,Zroto,Zrote,dZrotedT,dZrotodT
+   real(kind=rp) :: CI,Sl,T,ni,rho,tmp,a1,a2,a3,Zrot,Zh2ext,Zroto,Zrote,dZrotdT,dZrotedT,dZrotodT
 
    a1 = 0.0_rp
    a2 = 0.0_rp
@@ -1171,6 +1171,7 @@ contains
    Zrot = 0.0_rp
    Zrote = 0.0_rp
    Zroto = 0.0_rp
+   dZrotdT = 0.0_rp
    dZrotedT = 0.0_rp
    dZrotodT = 0.0_rp
  
@@ -1200,6 +1201,25 @@ contains
     kb*theta_vib*exp(-theta_vib/T)/(1.0_rp-exp(-theta_vib/T))
  
     !rotational part
+#ifdef USE_OPR_EQM
+     Zrot = 0.0_rp
+     dZrotdT = 0.0_rp
+     
+     do ir=0,101
+      Zrot = Zrot + &
+      (2.0_rp-(-1.0)**(ir))*(2.0_rp*ir+1.0_rp)*exp(-0.5_rp*ir*(ir+1)*theta_rot/T)
+     end do
+
+     do ir=0,101
+      dZrotdT = dZrotdT + &
+      (2.0_rp-(-1.0)**(ir))*(2.0_rp*ir+1.0_rp)*ir*(ir+1.0_rp)*exp(-0.5_rp*ir*(ir+1)*theta_rot/T) 
+     end do
+
+    Zh2ext = Zh2ext*Zrot 
+
+    Eh2 = Eh2 + kb*dZrotdT/Zrot 
+    
+#else
     Zroto = 0.0_rp
     Zrote = 0.0_rp
 
@@ -1232,8 +1252,9 @@ contains
 
     Zh2ext = Zh2ext*Zrot 
 
-    Eh2 = Eh2 + kb*0.25_rp*dZrotedT/Zrote + kb*0.75_rp*dZrotodT/Zroto - 0.75_rp*kb*theta_rot
-   
+    Eh2 = Eh2 + kb*0.25_rp*dZrotedT/Zrote + kb*0.75_rp*dZrotodT/Zroto - 0.75_rp*kb*theta_rot 
+#endif
+
     Zh2 = Zh2*Zh2ext
 
     a1 = (2.0_rp*pi*me*kb*T/h**2)**1.5_rp * &


### PR DESCRIPTION
## Summary

Add an option for assuming a equilibrium nuclear spin isomers for h2 in pig table generations

## Checklist

- [v ] Documentation was updated where behavior, options, or workflows changed.
- [v ] Relevant local checks were run.
- [ ] CI checks are passing (required before merge).
- [ ] If a new feature is implemented, it was verified by local test simulations
