### PR TITLE
Fix timmes kappa

### DIFF
--- a/source/source.F90
+++ b/source/source.F90
@@ -20812,7 +20812,7 @@ subroutine gmg_bcs(mgrid,lgrid,level)
   if (dlog10 <= drel10) then
     ocond = oh
   else if (dlog10 < drelim) then
-    farg = pi*(dlog10 - drel10)/(drelim - drel10)
+    farg  = pi*(dlog10 - drel10)/(drelim - drel10)
     ffac  = 0.5_rp*(1.0_rp - cos(farg))
     ocond = exp((1.0_rp-ffac)*log(oh) + ffac*log(ov))
   else

--- a/source/source.F90
+++ b/source/source.F90
@@ -20812,7 +20812,7 @@ subroutine gmg_bcs(mgrid,lgrid,level)
   if (dlog10 <= drel10) then
     ocond = oh
   else if (dlog10 < drelim) then
-    farg  = pi*(dlog10 - drel10)/0.3_rp
+    farg = pi*(dlog10 - drel10)/(drelim - drel10)
     ffac  = 0.5_rp*(1.0_rp - cos(farg))
     ocond = exp((1.0_rp-ffac)*log(oh) + ffac*log(ov))
   else


### PR DESCRIPTION
## Summary

fix a bug in the conductivity blending in subroutine sig99

## Related issue (optional)

The original code provided by cococubed produces a diagonal gap in the opacity.
This is probably caused by the use of a inconsistent denominator when linear interpolation is used in the conductivity blending.

## Verification

The line:
`farg  = pi*(dlog10 - drel10)/0.3_rp`
is updated to
` farg = pi*(dlog10 - drel10)/(drelim - drel10)`

This fix no longer produces the gap.

The fix is compared with another code from AMReX-Astro/Microphysics/conductivity/stellar.

The results are provided as reference
<img width="640" height="480" alt="after" src="https://github.com/user-attachments/assets/700f0f6e-6284-4c13-b5f1-15d21a4eb49c" />
<img width="640" height="480" alt="before" src="https://github.com/user-attachments/assets/bebf4520-5e7e-4f32-ba56-357abfd38850" />

